### PR TITLE
doc link to default version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ your own risk.
 **Source Code:**
     https://github.com/EtWnn/BinanceWatch
 **Documentation:**
-    https://binancewatch.readthedocs.io/en/latest/
+    https://binancewatch.readthedocs.io
 
 
 Features


### PR DESCRIPTION
change the documentation link to point towards the default version (latest or stable)